### PR TITLE
Clear local storage

### DIFF
--- a/css/settings/settings.css
+++ b/css/settings/settings.css
@@ -36,6 +36,18 @@ pre code {
   vertical-align: bottom;
 }
 
+h1 {
+  display: inline-block;
+}
+
+#version {
+  display: inline-block;
+  color: #CCC;
+  padding-left: 6px;
+  border-left: 1px solid #CCC;
+  margin-left: 6px;
+}
+
 p.empty {
   padding: 20px;
   color: #CCC;

--- a/html/settings/templates/header.html
+++ b/html/settings/templates/header.html
@@ -1,2 +1,4 @@
 
 <h1>{{title}} <img src="{{icon_path}}" class="title-icon" /></h1>
+
+<a href="https://github.com/gbaptista/luminous/releases/tag/0.0.5" id="version" target="_blank">0.0.5</a>

--- a/js/background/set_current_tab.js
+++ b/js/background/set_current_tab.js
@@ -13,12 +13,18 @@ var reset_counters_for_tab = function(tab_id) {
     if(!data_to_write) { data_to_write = {}; }
     if(!data_to_write[tab_id]) { data_to_write[tab_id] = {}; }
 
-    data_to_write[tab_id]['counters'] = {};
-    data_to_write[tab_id]['badge'] = { 'text': '', 'calls': 0 };
-
-    chrome.storage.local.set(data_to_write);
+    if(data_to_write[tab_id]['badge']) {
+      data_to_write[tab_id]['counters'] = {};
+      data_to_write[tab_id]['badge'] = { 'text': '', 'calls': 0 };
+      chrome.storage.local.set(data_to_write);
+    }
   });
+}
+
+var remove_data_for_tab = function(tab_id) {
+  chrome.storage.local.remove(tab_id.toString());
 }
 
 chrome.tabs.onCreated.addListener(function(tab) { reset_counters_for_tab(tab.id); });
 chrome.tabs.onUpdated.addListener(function(tab_id) { reset_counters_for_tab(tab_id); });
+chrome.tabs.onRemoved.addListener(function(tab_id) { remove_data_for_tab(tab_id); });

--- a/js/settings/stored-data/local.js
+++ b/js/settings/stored-data/local.js
@@ -37,7 +37,6 @@ $(document).ready(function() {
 
       if(Object.keys(local_data).length == 0) {
         load_template('html/settings/templates/stored-data/empty.html', function(template) {
-          settingsStorageEmptyText
           $('.tabs').html(
             Mustache.render(
               template, { text: chrome.i18n.getMessage('settingsStorageEmptyText') }


### PR DESCRIPTION
- Remove unecessay stored data from closed tabs.
- Fix code typo.
- Show current version in settings header.