### PR TITLE
Fix removeEventListener problem

### DIFF
--- a/html/demo-page.html
+++ b/html/demo-page.html
@@ -78,9 +78,19 @@
       <div id="ajaxContent" class="small-demo-box">XMLHttpRequest request...</div>
       <div id="fetchContent" class="small-demo-box">fetch request...</div>
       <div id="fetchContentAwait" class="small-demo-box">await fetch request...</div>
+
+      <div id="removeEventListener" class="small-demo-box">removeEventListener()</div>
     </div>
 
     <script type="text/javascript">
+      var to_be_removed_function_1 = function() {
+        alert('[1] not removed!');
+      };
+
+      document.getElementById('removeEventListener').addEventListener(
+        'mouseover', to_be_removed_function_1
+      );
+
       (function() { setTimeout(function() {
 
         var timeout_id = setTimeout(function() {
@@ -94,6 +104,22 @@
         }, 1500);
 
         clearInterval(interval_id);
+
+        var to_be_removed_function_2 = function() {
+          alert('[2] not removed!');
+        };
+
+        document.getElementById('removeEventListener').addEventListener(
+          'mouseover', to_be_removed_function_2
+        );
+
+        document.getElementById('removeEventListener').removeEventListener(
+          'mouseover', to_be_removed_function_2
+        );
+
+        document.getElementById('removeEventListener').removeEventListener(
+          'mouseover', to_be_removed_function_1
+        );
 
         var request = new XMLHttpRequest();
 

--- a/js/content/interceptor.js
+++ b/js/content/interceptor.js
@@ -129,6 +129,28 @@ XMLHttpRequest.prototype.send = function(body) {
   }
 }
 
+var removeEventListener_alias = {};
+
+var original_EventTarget_removeEventListener = EventTarget.prototype.removeEventListener;
+
+EventTarget.prototype.removeEventListener = function(type, listener, options) {
+  var super_this = this;
+
+  var value_to_return_a = original_EventTarget_removeEventListener.call(
+    super_this, type, listener, options
+  );
+
+  if(removeEventListener_alias[type][listener]) {
+    var value_to_return_b = original_EventTarget_removeEventListener.call(
+      super_this, type, removeEventListener_alias[type][listener], options
+    );
+
+    return value_to_return_a || value_to_return_b;
+  } else {
+    return value_to_return_a;
+  }
+};
+
 var original_EventTarget_addEventListener = EventTarget.prototype.addEventListener;
 
 EventTarget.prototype.addEventListener = function(type, listener, options) {
@@ -156,6 +178,10 @@ EventTarget.prototype.addEventListener = function(type, listener, options) {
         }
       }
     };
+
+    if(!removeEventListener_alias[type]) removeEventListener_alias[type] = {};
+
+    removeEventListener_alias[type][listener] = wraped_listener;
 
     return original_EventTarget_addEventListener.call(
       super_this, type, wraped_listener, options


### PR DESCRIPTION
This is a major issue for all websites.

Was discovered after investigations on the issue *"disable code injection on openstreetmap #36"*.

This should solve a lot of issues on other websites like *YouTube* and *Google Spreadsheets*.

More details about the expected behavior: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget