### PR TITLE
Fix reponse filters

### DIFF
--- a/html/demos/interception/simple.html
+++ b/html/demos/interception/simple.html
@@ -1,3 +1,18 @@
+
+
+<!DOCTYPE
+
+
+        html
+
+  PUBLIC
+
+     "-//W3C//DTD XHTML 1.0 Transitional//EN"
+
+   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+  
+>
+
 <script>
   var a = document.createElement('a');
   a.addEventListener('click', function(_) { return 'first script'; });

--- a/js/background/injections/content/filter_response_data.js
+++ b/js/background/injections/content/filter_response_data.js
@@ -33,9 +33,9 @@ if(injection_strategy != 'cookie') {
         filter.ondata = event => {
           var content = decoder.decode(event.data, {stream: true});
 
-          var match = /html.*?>/i.exec(content);
+          var match = /DOCTYPE(.|[\r\n])*?>/i.exec(content);
 
-          if(match) {
+          if(match && match.index < 10 && match[0].length < 200) {
             var to_replace = content.slice(0, match.index + match[0].length);
 
             content = content.replace(to_replace, to_replace + content_to_write);

--- a/js/background/injections/headers/security_polices.js
+++ b/js/background/injections/headers/security_polices.js
@@ -4,17 +4,34 @@ var update_security_policies = function(request_details) {
   if(should_intercept_request(url)) {
     for(let header of request_details.responseHeaders) {
       if(
-        (header.name.toLowerCase() == 'content-security-policy' || header.name.toLowerCase() == 'x-content-security-policy')
+        (
+          header.name.toLowerCase() == 'content-security-policy'
+          ||
+          header.name.toLowerCase() == 'x-content-security-policy'
+          ||
+          header.name.toLowerCase() == 'content-security-policy-report-only'
+          ||
+          header.name.toLowerCase() == 'x-content-security-policy-report-only'
+        )
         &&
         /script-src\s/i.test(header.value)
       ) {
-        var script_src_rules = header.value.split(/script-src\s/i)[1].split(';')[0];
+        var script_src_rules = header.value.split(/script-src\s/i);
 
-        if(!/unsafe-inline/i.test(script_src_rules)) {
-          header.value = header.value.replace(
-            /script-src\s{1,}/i,
-            "script-src 'nonce-3b34aae43a' "
-          );
+        for(i in script_src_rules) {
+          if(i > 0) {
+            var rule = script_src_rules[i].split(';')[0];
+
+            if(
+              rule && rule != '' && !/nonce-3b34aae43a/.test(rule)
+              &&
+              (!/unsafe-inline/i.test(rule) || /nonce-/i.test(rule))
+            ) {
+              header.value = header.value.replace(
+                rule, "'nonce-3b34aae43a' " + rule
+              );
+            }
+          }
         }
       }
     }

--- a/js/background/injections/headers/security_polices.js
+++ b/js/background/injections/headers/security_polices.js
@@ -16,7 +16,9 @@ var update_security_policies = function(request_details) {
         &&
         /script-src\s/i.test(header.value)
       ) {
-        var script_src_rules = header.value.split(/script-src\s/i);
+        header.value = header.value.replace(/script-src\s{1,}/ig, 'script-src ');
+
+        var script_src_rules = header.value.split(/script-src /i);
 
         for(i in script_src_rules) {
           if(i > 0) {
@@ -28,7 +30,7 @@ var update_security_policies = function(request_details) {
               (!/unsafe-inline/i.test(rule) || /nonce-/i.test(rule))
             ) {
               header.value = header.value.replace(
-                rule, "'nonce-3b34aae43a' " + rule
+                'script-src ' + rule, "script-src 'nonce-3b34aae43a' " + rule
               );
             }
           }

--- a/js/background/injections/settings.js
+++ b/js/background/injections/settings.js
@@ -91,7 +91,7 @@ var cached_urls = {};
 var url_for_request = function(request_details) {
   var url = request_details.url;
 
-  if(request_details.parentFrameId < 0) {
+  if(request_details.type == 'main_frame') {
     cached_urls[request_details.tabId] = request_details.url;
   } else {
     if(cached_urls[request_details.tabId]) {

--- a/js/background/strategy.js
+++ b/js/background/strategy.js
@@ -1,13 +1,13 @@
 var injection_strategy = 'cookie';
 
-// if(
-//   typeof browser !== 'undefined'
-//   &&
-//   browser.webRequest
-//   &&
-//   browser.webRequest.filterResponseData
-// ) {
-//
-//   // has filterResponseData support (Firefox 57+ only)
-//   injection_strategy = 'filterResponseData';
-// }
+if(
+  typeof browser !== 'undefined'
+  &&
+  browser.webRequest
+  &&
+  browser.webRequest.filterResponseData
+) {
+
+  // has filterResponseData support (Firefox 57+ only)
+  injection_strategy = 'filterResponseData';
+}

--- a/js/background/ui/badge.js
+++ b/js/background/ui/badge.js
@@ -150,12 +150,11 @@ chrome.runtime.onMessage.addListener(function (message, _sender) {
 });
 
 chrome.webRequest.onBeforeRequest.addListener(
-  function(details) {
+  function(request_details) {
     setTimeout(function() {
-      var tab_id = details.tabId.toString();
+      var tab_id = request_details.tabId.toString();
 
-      // main iframe?
-      if(details.parentFrameId < 0) { delete badges[tab_id]; }
+      if(request_details.type == 'main_frame') { delete badges[tab_id]; }
 
       update_badge_for_tab_id(true);
     }, 0);

--- a/js/content/strategy.js
+++ b/js/content/strategy.js
@@ -1,22 +1,22 @@
 var injection_strategy = 'cookie';
 
-// if(typeof browser !== 'undefined') {
-//   // Probably a Gecko-based browser
-//
-//   // TODO A very bad strategy, if there is any
-//   // spoofing of useragent, this will not work ...
-//   var current_browser = UAParser().browser;
-//
-//   if(
-//     current_browser.name == 'Firefox'
-//     &&
-//     parseInt(current_browser.major) < 57
-//   ) {
-//     // Firefox without filterResponseData support...
-//     injection_strategy = 'cookie';
-//   } else {
-//     // Let's hope it's a Firefox 57+ or
-//     // something with filterResponseData support.
-//     injection_strategy = 'filterResponseData';
-//   }
-// }
+if(typeof browser !== 'undefined') {
+  // Probably a Gecko-based browser
+
+  // TODO A very bad strategy, if there is any
+  // spoofing of useragent, this will not work ...
+  var current_browser = UAParser().browser;
+
+  if(
+    current_browser.name == 'Firefox'
+    &&
+    parseInt(current_browser.major) < 57
+  ) {
+    // Firefox without filterResponseData support...
+    injection_strategy = 'cookie';
+  } else {
+    // Let's hope it's a Firefox 57+ or
+    // something with filterResponseData support.
+    injection_strategy = 'filterResponseData';
+  }
+}


### PR DESCRIPTION
- We should inject code after `<!DOCTYPE ...` tag.
- Include `nonce` in `content-security-policy-report-only` header. (_Google_ sites issues).
- Improve nonce header injection.
- Use `request_details.type` instead of `request_details.parentFrameId` to determine `main_frame` requests.
- Enable `filterResponseData` for Firefox 57+ browsers. :crossed_fingers: 