### PR TITLE
[WIP] Take a Note Experiment

### DIFF
--- a/css/popup/popup.css
+++ b/css/popup/popup.css
@@ -234,3 +234,48 @@ body.zoom-in { font-size: 17px; }
   width: 164px;
   padding: 8px 4px 16px 4px;
 }
+
+#note-container {
+  position: fixed;
+  top:0;
+  left:0;
+  width: 100%;
+  height: 100%;
+  background-color:#FFF;
+  opacity: 0.98;
+  padding: 20px;
+}
+
+#note-container textarea {
+  display: block;
+  width: 90%;
+  height: 100px;
+}
+
+.waiting-for-note, .waiting-for-note * {
+  cursor: crosshair!important;
+}
+
+.safe_level {
+  display: inline-block;
+  padding: 3px;
+  margin: 2px;
+  color:white;
+  text-shadow: 1px 1px 1px #222;
+  font-weight: bold;
+  padding-right: 10px;
+  font-size: 17px;
+  background-color: #666;
+}
+
+/* .safe_level_01 { background-color: #C75546; }
+.safe_level_02 { background-color: #CA9E5A; }
+.safe_level_03 { background-color: #C0BE78; }
+.safe_level_04 { background-color: #5BB78C; }
+.safe_level_05 { background-color: #05927B; } */
+
+.safe_level_01 { background-color: #DC1C30; }
+.safe_level_02 { background-color: #F99F0B; }
+.safe_level_03 { background-color: #CFD028; }
+.safe_level_04 { background-color: #6E923C; }
+.safe_level_05 { background-color: #365138; }

--- a/html/popup/templates/options.html
+++ b/html/popup/templates/options.html
@@ -30,6 +30,8 @@
       <input type="checkbox" name="apply_to_default" value="true" {{#apply_to_default}} checked {{/apply_to_default}} />
       {{apply_to_default_title}}
     </label>
+    <br>
+    <button id="take-a-note" {{#waiting_for_note}}disabled{{/waiting_for_note}}>take a note</button>
   </div>
 
   <div class="col-2">

--- a/html/popup/templates/take-a-note.html
+++ b/html/popup/templates/take-a-note.html
@@ -1,0 +1,36 @@
+<div id="note-container">
+
+  <form>
+    domain: <strong>{{domain}}</strong>
+    <br>
+    kind: <strong>{{kind}}</strong>
+    <br>
+    type: <strong>{{type}}</strong>
+    <br><br>
+    How safe is it to block it?
+    <br>
+    <div class="safe_level safe_level_01"><input type="radio" checked> impossible to use the site without this</div>
+    <br>
+    <div class="safe_level safe_level_02"><input type="radio"> the site breaks, complicated workarounds are needed to use</div>
+    <br>
+    <div class="safe_level safe_level_03"><input type="radio"> breaks something, but it's possible to live without it</div>
+    <br>
+    <div class="safe_level safe_level_04"><input type="radio"> breaks something but remains usable</div>
+    <br>
+    <div class="safe_level safe_level_05"><input type="radio"> totally safe</div>
+    <br><br>
+    What's the problem?
+    <br>
+    <div class="safe_level"><input type="checkbox"> can't login</div>
+    <br>
+    <div class="safe_level"><input type="checkbox"> broken layout</div>
+    <br>
+    <div class="safe_level"><input type="checkbox"> video/music player not working</div>
+    <br><br>
+    More details:
+    <textarea></textarea>
+    <br>
+    <button type="submit">save</button>
+  </form>
+
+</div>


### PR DESCRIPTION
A major challenge in using this extension is knowing what to block or not. It would be awesome to have some "simplified mode" where blocking is done automatically. It's a hard goal, but I believe that with the collaboration of several people it is certainly possible!

By re-reading some discussions and suggestions, I see that creating notes on each block can be very useful. The macro idea is:

1. Create a simple way to write down details about each block.
2. Create a way where each person can share their notes (only if they want and in a transparent way where they know exactly what they are sharing, respecting their privacy).
3. Arrange these shared notes in a public Luminous database.
4. Use this database to create a "simplified mode" where codes are automatically identified and blocked (keeping the current format as an "advanced mode").

This PR is about the step **1.**.

An ugly draft just to give a visual context to the idea and start the discussion:

We can have a "take a note" button that turns the mouse into a crosshair:
> ![selection_374](https://user-images.githubusercontent.com/29520/37376162-d90f0d66-2701-11e8-8205-938db13108d4.jpg)

By clicking on any of the blocks, a form would open to note details about it:
> ![selection_375](https://user-images.githubusercontent.com/29520/37376208-0c21c13a-2702-11e8-81e4-964e6e129e5f.jpg)

Sounds like an interesting idea?
What should be asked on the form?

I would love to hear more thoughts about it so I could build a solution that would help everyone.

#### Related to:
- *is this meant to be a blocker? #18*
- *Items we can safely block (user feedback & suggestions) #49*
- *option to take notes #63*
- *heads up: Luminous: JavaScript events blocker [ghacksuserjs/ghacks-user.js#348](https://github.com/ghacksuserjs/ghacks-user.js/issues/348)*
