### PR TITLE
Fix Firefox binary files issue

### DIFF
--- a/js/background/injections/settings.js
+++ b/js/background/injections/settings.js
@@ -76,7 +76,7 @@ chrome.storage.onChanged.addListener(function(changes, namespace) {
 });
 
 var should_intercept_request = function(url) {
-  if(cached_settings['injection_disabled']['general']) {
+  if(!settings_defined || cached_settings['injection_disabled']['general']) {
     return false;
   } else {
     a_element.href = url;


### PR DESCRIPTION
Fix *Images and PDF files are not opening in Firefox. #93*.

We should check whether the content is from a binary file or not before inejting the code.