### PR TITLE
Improve filterResponseData

### DIFF
--- a/js/background/injections/content/filter_response_data.js
+++ b/js/background/injections/content/filter_response_data.js
@@ -18,15 +18,13 @@ if(injection_strategy != 'cookie') {
       should_intercept = /html/.test(subtype);
     }
 
-    console.log('should_intercept?', type, subtype, should_intercept);
-
     return should_intercept;
   }
 
   var interceptor_html_string = undefined;
   var data_html_string = undefined;
 
-  // TODO remove cache for development enviroment
+  // TODO: remove cache for development enviroment
   load_interceptor_element('filterResponseData', function(element) {
     interceptor_html_string = element_to_html_string(element);
   });

--- a/js/background/injections/content/filter_response_data.js
+++ b/js/background/injections/content/filter_response_data.js
@@ -14,8 +14,7 @@ if(injection_strategy != 'cookie') {
 
     // TODO: Improve content_type check to fix issue #107:
     // https://github.com/gbaptista/luminous/issues/107
-
-    if (type == 'text') {
+    if (['text', 'application'].includes(type)) {
       should_intercept = /html/.test(subtype);
     }
 

--- a/js/background/injections/content/filter_response_data.js
+++ b/js/background/injections/content/filter_response_data.js
@@ -1,4 +1,29 @@
 if(injection_strategy != 'cookie') {
+
+  var should_intercept_content_type = function(content_type) {
+    var should_intercept = false;
+
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+    var splitted_content_type = content_type.toLowerCase().split(
+      ';'
+    )[0].toLowerCase().split('/');
+
+    var type = splitted_content_type[0];
+    var subtype = splitted_content_type[1];
+
+    // TODO: Improve content_type check to fix issue #107:
+    // https://github.com/gbaptista/luminous/issues/107
+
+    if (type == 'text') {
+      should_intercept = /html/.test(subtype);
+    }
+
+    console.log('should_intercept?', type, subtype, should_intercept);
+
+    return should_intercept;
+  }
+
   var interceptor_html_string = undefined;
   var data_html_string = undefined;
 
@@ -13,6 +38,22 @@ if(injection_strategy != 'cookie') {
 
   var encoder = new TextEncoder();
   var decoder = new TextDecoder('utf-8');
+
+  var requests_content_types = {};
+
+  var detect_request_type = function(request_details) {
+    requests_content_types[request_details.requestId] = undefined;
+
+    var url = url_for_request(request_details);
+
+    if(should_intercept_request(url)) {
+      for(let header of request_details.responseHeaders) {
+        if(header.name.toLowerCase() == 'content-type') {
+          requests_content_types[request_details.requestId] = header.value;
+        }
+      }
+    }
+  }
 
   var inject_interceptor_and_settings = function(request_details) {
     var url = url_for_request(request_details);
@@ -34,15 +75,14 @@ if(injection_strategy != 'cookie') {
         var content_to_write = options_html_string + data_html_string + interceptor_html_string;
 
         filter.ondata = event => {
+          var content_type = requests_content_types[request_details.requestId];
+
           var content = decoder.decode(event.data, {stream: true});
 
-
-          // TODO: Improve binary check to fix issue #107:
-          // https://github.com/gbaptista/luminous/issues/107
           // binary content? Image, PDF...
           var binary = /\0/.exec(content);
 
-          if(!binary) {
+          if(!binary && should_intercept_content_type(content_type)) {
             var match = /DOCTYPE(.|[\r\n])*?>/i.exec(content);
 
             if(match && match.index < 10 && match[0].length < 200) {
@@ -65,6 +105,13 @@ if(injection_strategy != 'cookie') {
 
     return {};
   }
+
+  chrome.webRequest.onHeadersReceived.addListener(
+    detect_request_type,
+    { urls: ['<all_urls>'], types: ['main_frame', 'sub_frame'] },
+    ['responseHeaders', 'blocking']
+  );
+
 
   chrome.webRequest.onBeforeRequest.addListener(
     inject_interceptor_and_settings,

--- a/js/background/injections/content/filter_response_data.js
+++ b/js/background/injections/content/filter_response_data.js
@@ -17,6 +17,8 @@ if(injection_strategy != 'cookie') {
   var inject_interceptor_and_settings = function(request_details) {
     var url = url_for_request(request_details);
 
+    // TODO: Improve should_intercept_request to fix issue #107:
+    // https://github.com/gbaptista/luminous/issues/107
     if(should_intercept_request(url)) {
       var options = full_options_for_url(url);
 
@@ -34,6 +36,9 @@ if(injection_strategy != 'cookie') {
         filter.ondata = event => {
           var content = decoder.decode(event.data, {stream: true});
 
+
+          // TODO: Improve binary check to fix issue #107:
+          // https://github.com/gbaptista/luminous/issues/107
           // binary content? Image, PDF...
           var binary = /\0/.exec(content);
 

--- a/js/background/strategy.js
+++ b/js/background/strategy.js
@@ -10,11 +10,7 @@ if(
   // TODO: Use sync_data['advanced']['injection_strategy']
   //       if 'TryFilterResponseData': 'filterResponseData'
   //                             else: 'cookie'
-  // Temporarily disabled because of issue #107:
-  // https://github.com/gbaptista/luminous/issues/107
 
   // has filterResponseData support (Firefox 57+ only)
-  // injection_strategy = 'filterResponseData';
-
-  injection_strategy = 'cookie';
+  injection_strategy = 'filterResponseData';
 }

--- a/js/background/strategy.js
+++ b/js/background/strategy.js
@@ -7,7 +7,14 @@ if(
   &&
   browser.webRequest.filterResponseData
 ) {
+  // TODO: Use sync_data['advanced']['injection_strategy']
+  //       if 'TryFilterResponseData': 'filterResponseData'
+  //                             else: 'cookie'
+  // Temporarily disabled because of issue #107:
+  // https://github.com/gbaptista/luminous/issues/107
 
   // has filterResponseData support (Firefox 57+ only)
-  injection_strategy = 'filterResponseData';
+  // injection_strategy = 'filterResponseData';
+
+  injection_strategy = 'cookie';
 }

--- a/js/content/initializer.js
+++ b/js/content/initializer.js
@@ -1,3 +1,18 @@
+var should_inject_this_document = function() {
+  // thanks to: https://github.com/EFForg/privacybadger/pull/1954
+  if (
+    document instanceof HTMLDocument === false &&
+    (
+      document instanceof XMLDocument === false ||
+      document.createElement('div') instanceof HTMLDivElement === false
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 var intialize_luminous_injections = function(from) {
   if(from == 'cookie') {
     var injection_enabled = Cookies.get('le');
@@ -10,7 +25,7 @@ var intialize_luminous_injections = function(from) {
 
     if(from == 'cookie') {
       if(injection_enabled != 'f') {
-        fn(true);
+        fn(should_inject_this_document());
       }
     } else {
       fn(false);

--- a/js/content/strategy.js
+++ b/js/content/strategy.js
@@ -15,8 +15,16 @@ if(typeof browser !== 'undefined') {
     // Firefox without filterResponseData support...
     injection_strategy = 'cookie';
   } else {
-    // Let's hope it's a Firefox 57+ or
-    // something with filterResponseData support.
-    injection_strategy = 'filterResponseData';
+    // TODO: Use sync_data['advanced']['injection_strategy']
+    //       if 'TryFilterResponseData': 'filterResponseData'
+    //                             else: 'cookie'
+    // Temporarily disabled because of issue #107:
+    // https://github.com/gbaptista/luminous/issues/107
+
+    // Let's hope it's a Firefox 57+ or something
+    // with filterResponseData support.
+    // injection_strategy = 'filterResponseData';
+
+    injection_strategy = 'cookie';
   }
 }

--- a/js/content/strategy.js
+++ b/js/content/strategy.js
@@ -18,13 +18,9 @@ if(typeof browser !== 'undefined') {
     // TODO: Use sync_data['advanced']['injection_strategy']
     //       if 'TryFilterResponseData': 'filterResponseData'
     //                             else: 'cookie'
-    // Temporarily disabled because of issue #107:
-    // https://github.com/gbaptista/luminous/issues/107
 
     // Let's hope it's a Firefox 57+ or something
     // with filterResponseData support.
-    // injection_strategy = 'filterResponseData';
-
-    injection_strategy = 'cookie';
+    injection_strategy = 'filterResponseData';
   }
 }


### PR DESCRIPTION
Rely on the content_type of the request to decide if the code should be injected with `filterResponseData`:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types

Examples:

`text/html` > inject
`application/xhtml+xml` > inject
`text/plain` > don't inject
`image/svg+xml` > don't inject

Do not inject scripts into non-html documents for Chrome and old versions of Firefox. Reference: *EFForg/privacybadger#1954*